### PR TITLE
Space between copy and footer

### DIFF
--- a/web/src/lib/components/QR.svelte
+++ b/web/src/lib/components/QR.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div class="qr glowbox"><a href="lightning:{lnurl}">{@html qr}</a></div>
-<div class="mt-10 flex justify-center items-center">
+<div class="mt-10 pb-4 flex justify-center items-center">
     <input value={lnurl} type="text" class="input input-bordered w-full max-w-xs" disabled />
     <button class="btn ml-2 w-20" on:click={copy}>{#if copied}Copied{:else}Copy!{/if}</button>
 </div>


### PR DESCRIPTION
Add padding below "copy" button to create space between login and footer.