### PR TITLE
Remove reserve not met message from auctions without a reserve

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -138,7 +138,7 @@ def me(user):
 @api_blueprint.route('/api/users/me/verify-twitter', methods=['PUT'])
 @user_required
 def verify_twitter(user):
-    liking_usernames = get_twitter().get_tweet_likes(user.twitter_username_verification_tweet_id)
+    liking_usernames = get_twitter().get_tweet_likes(user.twitter_username_verification_tweet_id).lower()
     if not user.twitter_username.lower() in liking_usernames:
         return jsonify({'message': "Please like the tweet to verify your username."}), 400
     else:

--- a/api/api.py
+++ b/api/api.py
@@ -138,7 +138,7 @@ def me(user):
 @api_blueprint.route('/api/users/me/verify-twitter', methods=['PUT'])
 @user_required
 def verify_twitter(user):
-    liking_usernames = get_twitter().get_tweet_likes(user.twitter_username_verification_tweet_id).lower()
+    liking_usernames = get_twitter().get_tweet_likes(user.twitter_username_verification_tweet_id)
     if not user.twitter_username.lower() in liking_usernames:
         return jsonify({'message': "Please like the tweet to verify your username."}), 400
     else:

--- a/web/src/lib/components/Auction.svelte
+++ b/web/src/lib/components/Auction.svelte
@@ -151,7 +151,7 @@
                                 <Countdown bind:this={finalCountdown} untilDate={new Date(auction.end_date)} />
                             </div>
                         {/if}
-                        {#if !auction.reserve_bid_reached}
+                        {#if !auction.reserve_bid_reached && auction.reserve_bid > 0}
                             <p class="my-3 w-full text-xl text-center">
                                 Reserve not met!
                             </p>


### PR DESCRIPTION
Reserve not met message should only display if reserve is greater than zero.