### PR TITLE
Increase login expiration time to 2h

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -52,7 +52,7 @@ def login():
     lnauth = m.LnAuth.query.filter_by(k1=request.args['k1']).first()
 
     if not lnauth or lnauth.created_at < datetime.utcnow() - timedelta(minutes=m.LnAuth.EXPIRE_MINUTES):
-        return jsonify({'message': "Verification failed."}), 400
+        return jsonify({'message': "Login token expired."}), 410
 
     if 'key' in request.args and 'sig' in request.args:
         # request made by the Lightning wallet, includes a key and a signature

--- a/api/models.py
+++ b/api/models.py
@@ -74,7 +74,7 @@ class State(db.Model):
 class LnAuth(db.Model):
     __tablename__ = 'lnauth'
 
-    EXPIRE_MINUTES = 10
+    EXPIRE_MINUTES = 120
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     k1 = db.Column(db.String(128), nullable=False, unique=True, index=True)

--- a/web/src/lib/components/Login.svelte
+++ b/web/src/lib/components/Login.svelte
@@ -38,6 +38,9 @@
                 localStorage.setItem('token', response.token);
                 dispatch('loginEvent', {})
                 onLogin(response.user);
+            },
+            () => {
+                dispatch('loginTokenExpiredEvent', {})
             });
     }
 

--- a/web/src/lib/components/LoginModal.svelte
+++ b/web/src/lib/components/LoginModal.svelte
@@ -4,7 +4,7 @@
     import Login from "$lib/components/Login.svelte";
 
     let login : Login | null;
-    let isModalOpen = false
+    let isModalOpen = false;
 
     export function show(onLoginFunction) {
         if (typeof onLoginFunction === 'function') {
@@ -28,8 +28,12 @@
 <div class="modal" class:modal-open={isModalOpen}>
     <div class="modal-box relative flex justify-center items-center w-10/12 max-w-2xl">
         <label for="modal-box" class="btn btn-sm btn-circle absolute right-2 top-2" on:click={() => hide()} on:keypress={() => hide()}>✕</label>
-        <div class="w-full" style="margin-top: -40px">
-            <Login bind:this={login} on:loginEvent={e => hide()} {onLogin} />
+        <div class="w-full" style="margin-top: -40px" id="loginDiv">
+            <Login
+                    bind:this={login}
+                    on:loginEvent={e => hide()}
+                    on:loginTokenExpiredEvent={e => hide()}
+                    {onLogin} />
         </div>
     </div>
 </div>

--- a/web/src/lib/services/api.ts
+++ b/web/src/lib/services/api.ts
@@ -106,7 +106,7 @@ export interface GetLoginSuccessResponse {
     user: User;
 }
 
-export function getLogin(k1, initialResponseCB: (response: GetLoginInitialResponse) => void, waitResponseCB: () => void, successResponseCB: (response: GetLoginSuccessResponse) => void) {
+export function getLogin(k1, initialResponseCB: (response: GetLoginInitialResponse) => void, waitResponseCB: () => void, successResponseCB: (response: GetLoginSuccessResponse) => void, expiredCB: () => void) {
     fetchAPI("/login" + (k1 ? `?k1=${k1}` : ""), 'GET', null, null,
         response => {
             if (response.status === 200) {
@@ -119,6 +119,12 @@ export function getLogin(k1, initialResponseCB: (response: GetLoginInitialRespon
                         } else {
                             waitResponseCB();
                         }
+                    }
+                );
+            } else if (response.status === 410) {
+                response.json().then(
+                    () => {
+                        expiredCB();
                     }
                 );
             }


### PR DESCRIPTION
Increase login expiration time to 2h and make the modal dissapear when the first request has been done which returns 410 (expired).