### PR TITLE
Update DaisyUI to latest version 2.46.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "@sveltejs/kit": "next",
         "autoprefixer": "10.x",
         "btc2fiat": "*",
-        "daisyui": "2.x",
+        "daisyui": "^2.46.1",
         "eslint": "8.x",
         "eslint-plugin-svelte3": "4.x",
         "npm-run-all": "4.x",
@@ -847,15 +847,19 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.39.0.tgz",
-      "integrity": "sha512-r3vbDI+pafB//QFfKJMkMxLlKGjdk21O/NieG+zY+LXH4hinyAA1/2/jE1+fNR+qQbuBL8USnN4wR3grG78nHQ==",
+      "version": "2.46.1",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.46.1.tgz",
+      "integrity": "sha512-i59+nLuzzPAVOhNhot3KLtt6stfYeCIPXs9uiLcpXjykpqxHfBA3W6hQWOUWPMwfqhyQd0WKub3sydtPGjzLtA==",
       "dev": true,
       "dependencies": {
         "color": "^4.2",
         "css-selector-tokenizer": "^0.8.0",
         "postcss-js": "^4.0.0",
         "tailwindcss": "^3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/daisyui"
       },
       "peerDependencies": {
         "autoprefixer": "^10.0.2",
@@ -4721,9 +4725,9 @@
       "dev": true
     },
     "daisyui": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.39.0.tgz",
-      "integrity": "sha512-r3vbDI+pafB//QFfKJMkMxLlKGjdk21O/NieG+zY+LXH4hinyAA1/2/jE1+fNR+qQbuBL8USnN4wR3grG78nHQ==",
+      "version": "2.46.1",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.46.1.tgz",
+      "integrity": "sha512-i59+nLuzzPAVOhNhot3KLtt6stfYeCIPXs9uiLcpXjykpqxHfBA3W6hQWOUWPMwfqhyQd0WKub3sydtPGjzLtA==",
       "dev": true,
       "requires": {
         "color": "^4.2",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "@sveltejs/kit": "next",
     "autoprefixer": "10.x",
     "btc2fiat": "*",
-    "daisyui": "2.x",
+    "daisyui": "^2.46.1",
     "eslint": "8.x",
     "eslint-plugin-svelte3": "4.x",
     "npm-run-all": "4.x",


### PR DESCRIPTION
This version has lot of fixes for Safari and others.

Besides that, I need this for the Nostr chat.

@ibz maybe we can wait to merge this until after the next week deploy. I'll use it locally to see if everything works fine.