### PR TITLE
Fix Svelte warning message on npm install

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,6 @@
     "build-production": "vite build --mode production",
     "package": "svelte-kit package",
     "preview": "svelte-kit preview",
-    "prepare": "svelte-kit sync",
     "check": "svelte-check --tsconfig ./jsconfig.json",
     "check:watch": "svelte-check --tsconfig ./jsconfig.json --watch",
     "lint": "eslint --ignore-path .gitignore ."


### PR DESCRIPTION
I'm getting this message while `npm i` our `/web` project:

`svelte-kit sync now runs on "postinstall" — please remove the "prepare" script from your package.json`

Removing this line, the warning message dissapears.