### PR TITLE
Fix "Be the first to bid!" is shown even when auction has ended

### DIFF
--- a/web/src/lib/components/ItemView.svelte
+++ b/web/src/lib/components/ItemView.svelte
@@ -328,6 +328,8 @@
                                     {#if !item.ended}
                                         {#if item instanceof Auction}
                                             {#if !item.bids.length}
+                                                <p class="text-3xl text-center pt-24">Starting bid is <AmountFormatter satsAmount={item.starting_bid} />.</p>
+                                                <p class="text-2xl text-center pt-2">Be the first to bid!</p>
                                                 <p class="text-center pt-12 mb-4">Place your bid below</p>
                                             {/if}
                                             <div class="flex justify-center items-center">
@@ -396,11 +398,6 @@
                             <div class="mt-2">
                                 <BidList auction={item} />
                             </div>
-                        {:else}
-                            {#if !item.is_mine}
-                                <p class="text-3xl text-center pt-24">Starting bid is <AmountFormatter satsAmount={item.starting_bid} />.</p>
-                                <p class="text-2xl text-center pt-2">Be the first to bid!</p>
-                            {/if}
                         {/if}
                     {/if}
                 </div>


### PR DESCRIPTION
The message "Starting bid is x sats. Be the first to bid!" is shown even when the auction has ended. This fixes that.

@ibz I was thinking maybe the two messages (Be the first to bid / place your bid below) would be redundant, but I've tried and it's not so bad. What do you think?

![image](https://user-images.githubusercontent.com/547169/211273638-40657298-2e6c-48ae-affe-f62757e0aff7.png)
