### PR TITLE
Fix Svelte warning and maybe fix some potential problems

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -17,6 +17,8 @@
     %sveltekit.head%
   </head>
   <body>
-    %sveltekit.body%
+    <div style="display: contents">
+      %sveltekit.body%
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Loading our web app in Firefox gives this warning:

```
Placing %sveltekit.body% directly inside <body> is not recommended, as your app may break for users who have certain browser extensions installed.

Consider wrapping it in an element:

<div style="display: contents">
  %sveltekit.body%
</div>
```

They talk about it here: https://github.com/sveltejs/kit/discussions/7585

I'm adding the recommended fix so we get rid of the warning and maybe we're lucky and fix some other random problem.

I've loaded mostly all our pages and they seem to display correctly.