### PR TITLE
Fix new metatags functions

### DIFF
--- a/web/src/lib/components/ItemView.svelte
+++ b/web/src/lib/components/ItemView.svelte
@@ -17,7 +17,7 @@
     import Gallery from "$lib/components/Gallery.svelte";
     import SaleFlow from "$lib/components/SaleFlow.svelte";
     import { page } from "$app/stores";
-    import { getBaseUrl } from "$lib/utils";
+    import { getBaseUrl, getShortTitle, getShortDescription } from "$lib/utils";
     import TweetButton from "$lib/components/TweetButton.svelte";
     import LoginModal from "$lib/components/LoginModal.svelte";
 
@@ -127,24 +127,26 @@
     onDestroy(stopRefresh);
 </script>
 
+{#if serverLoadedItem}
 <MetaTags
-    title={serverLoadedItem?.getShortTitle()}
-    description={serverLoadedItem?.getShortDescription()}
+    title={getShortTitle(serverLoadedItem.title)}
+    description={getShortDescription(serverLoadedItem.description)}
     openGraph={{
         site_name: import.meta.env.VITE_SITE_NAME,
         type: 'website',
         url: $page.url.href,
-        title: serverLoadedItem?.getShortTitle(),
-        description: serverLoadedItem?.getShortDescription(),
-        images: [{ url: serverLoadedItem && serverLoadedItem.media.length ? serverLoadedItem.media[0].url : "/images/logo.jpg" }],
+        title: getShortTitle(serverLoadedItem.title),
+        description: getShortDescription(serverLoadedItem.description),
+        images: [{ url: serverLoadedItem.media.length ? serverLoadedItem.media[0].url : "/images/logo.jpg" }],
     }}
     twitter={{
         site: import.meta.env.VITE_TWITTER_USER,
         handle: import.meta.env.VITE_TWITTER_USER,
         cardType: "summary_large_image",
-        imageAlt: serverLoadedItem?.getShortTitle(),
+        imageAlt: getShortTitle(serverLoadedItem.title),
     }}
 />
+{/if}
 
 {#if item}
     <div class="lg:w-2/3 mx-auto p-2">

--- a/web/src/lib/types/auction.ts
+++ b/web/src/lib/types/auction.ts
@@ -1,4 +1,4 @@
-import { isProduction, SHORT_TITLE_LIMIT, SHORT_DESCRIPTION_LIMIT } from "$lib/utils";
+import { isProduction } from "$lib/utils";
 import type { IEntity } from "$lib/types/base";
 import { Category, type Item, type Media, TIME_ITEM_DESCRIPTION_PLACEHOLDER } from "$lib/types/item";
 import { type Sale, fromJson as saleFromJson } from "$lib/types/sale";
@@ -59,14 +59,6 @@ export class Auction implements IEntity, Item {
 
     public validate(forSave: boolean = false) {
         return !(this.title.length === 0 || this.description.length === 0);
-    }
-
-    public getShortTitle(): string {
-        return this.title.substring(0, SHORT_TITLE_LIMIT);
-    }
-
-    public getShortDescription(): string {
-        return this.description.substring(0, SHORT_DESCRIPTION_LIMIT);
     }
 
     public topBid() {

--- a/web/src/lib/types/campaign.ts
+++ b/web/src/lib/types/campaign.ts
@@ -1,6 +1,5 @@
 import type { IEntity } from "$lib/types/base";
 import type { IAccount } from "$lib/types/user";
-import { SHORT_TITLE_LIMIT, SHORT_DESCRIPTION_LIMIT } from "$lib/utils";
 
 export class Campaign implements IEntity {
     static SAVED_FIELDS = ['name', 'description', 'xpub'];
@@ -14,14 +13,6 @@ export class Campaign implements IEntity {
     is_mine: boolean = true;
     xpub: string | null = null;
     owner: IAccount = {nym: null, displayName: null, profileImageUrl: null, email: null, emailVerified: false, telegramUsername: null, telegramUsernameVerified: false, twitterUsername: null, twitterUsernameVerified: false};
-
-    public getShortName(): string {
-        return this.name.substring(0, SHORT_TITLE_LIMIT);
-    }
-
-    public getShortDescription(): string {
-        return this.description.substring(0, SHORT_DESCRIPTION_LIMIT);
-    }
 
     public validate(forSave: boolean = false) {
         return true;

--- a/web/src/lib/types/listing.ts
+++ b/web/src/lib/types/listing.ts
@@ -1,4 +1,3 @@
-import { SHORT_TITLE_LIMIT, SHORT_DESCRIPTION_LIMIT } from "$lib/utils";
 import type { IEntity } from "$lib/types/base";
 import { Category, type Item, type Media, TIME_ITEM_DESCRIPTION_PLACEHOLDER } from "$lib/types/item";
 import { type Sale, fromJson as saleFromJson } from "$lib/types/sale";
@@ -35,14 +34,6 @@ export class Listing implements IEntity, Item {
             || this.description.length === 0
             || this.price_usd === null || this.price_usd === 0
             || this.available_quantity === null || this.available_quantity === 0);
-    }
-
-    public getShortTitle(): string {
-        return this.title.substring(0, SHORT_TITLE_LIMIT);
-    }
-
-    public getShortDescription(): string {
-        return this.description.substring(0, SHORT_DESCRIPTION_LIMIT);
     }
 
     public toJson() {

--- a/web/src/lib/types/user.ts
+++ b/web/src/lib/types/user.ts
@@ -1,5 +1,3 @@
-import { SHORT_TITLE_LIMIT, SHORT_DESCRIPTION_LIMIT } from "$lib/utils";
-
 export interface IAccount {
     nym: string | null;
     displayName: string | null;
@@ -45,22 +43,6 @@ export class User implements IAccount {
     hasPastListings: boolean = false;
     isModerator: boolean = false;
     badges: Badge[] = [];
-
-    public getShortStallName(): string {
-        if (this.stallName) {
-            return this.stallName.substring(0, SHORT_TITLE_LIMIT);
-        } else {
-            return this.nym + "'s Stall";
-        }
-    }
-
-    public getShortStallDescription(): string {
-        if (this.stallDescription) {
-            return this.stallDescription.substring(0, SHORT_DESCRIPTION_LIMIT);
-        } else {
-            return "Check out my Plebeian Market stall!";
-        }
-    }
 
     public hasBadge(badge) {
         for (const b of this.badges) {

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -66,3 +66,19 @@ export function usd2sats(usd: number, btc2usd: number | null): number | null {
 export function formatBTC(sats: number) {
     return (1 / SATS_IN_BTC * sats).toFixed(9);
 }
+
+export function getShortTitle(longTitle): string {
+    if (longTitle) {
+        return longTitle.substring(0, SHORT_TITLE_LIMIT);
+    }
+
+    return '';
+}
+
+export function getShortDescription(longDescription): string {
+    if (longDescription) {
+        return longDescription.substring(0, SHORT_DESCRIPTION_LIMIT);
+    }
+
+    return '';
+}

--- a/web/src/routes/campaigns/[...key]/+page.svelte
+++ b/web/src/routes/campaigns/[...key]/+page.svelte
@@ -10,6 +10,7 @@
     import { token, user } from "$lib/stores";
     import { MetaTags } from "svelte-meta-tags";
     import { page } from "$app/stores";
+    import {getShortTitle, getShortDescription} from "$lib/utils";
     import FaketoshiPNG from "$lib/images/Bitko-Illustration-Faketoshi.png?url"
 
     /** @type {import('./$types').PageData} */
@@ -45,14 +46,14 @@
 
 {#if data.serverLoadedCampaign}
 <MetaTags
-        title={data.serverLoadedCampaign.getShortName()}
-        description={data.serverLoadedCampaign.getShortDescription()}
+        title={getShortTitle(data.serverLoadedCampaign.name)}
+        description={getShortDescription(data.serverLoadedCampaign.description)}
         openGraph={{
             site_name: import.meta.env.VITE_SITE_NAME,
             type: "website",
             url: $page.url.href,
-            title: data.serverLoadedCampaign.getShortName(),
-            description: data.serverLoadedCampaign.getShortDescription(),
+            title: getShortTitle(data.serverLoadedCampaign.name),
+            description: getShortDescription(data.serverLoadedCampaign.description),
             images: [
               {
                 url: FaketoshiPNG,
@@ -64,7 +65,7 @@
             site: import.meta.env.VITE_TWITTER_USER,
             handle: import.meta.env.VITE_TWITTER_USER,
             cardType: "summary_large_image",
-            imageAlt: data.serverLoadedCampaign.getShortName(),
+            imageAlt: getShortTitle(data.serverLoadedCampaign.name),
         }}
 />
 {/if}

--- a/web/src/routes/stall/[nym]/+page.svelte
+++ b/web/src/routes/stall/[nym]/+page.svelte
@@ -12,6 +12,7 @@
     import { token, user } from "$lib/stores";
     import { MetaTags } from "svelte-meta-tags";
     import { page } from "$app/stores";
+    import {getShortTitle, getShortDescription} from "$lib/utils";
 
     /** @type {import('./$types').PageData} */
     export let data;
@@ -46,23 +47,30 @@
         }
     });
 
+    let stallTitle: string = '';
+    let stallDescription: string = '';
+
     let serverLoadedUser = data.serverLoadedUser;
+    if (serverLoadedUser) {
+        stallTitle = serverLoadedUser.stall_name ? getShortTitle(serverLoadedUser.stall_name) : serverLoadedUser.nym + "'s Stall";
+        stallDescription = serverLoadedUser.stall_description ? getShortDescription(serverLoadedUser.stall_description) : "Check out my Plebeian Market stall!"
+    }
 </script>
 
 {#if serverLoadedUser}
     <MetaTags
-            title={serverLoadedUser.getShortStallName()}
-            description={serverLoadedUser.getShortStallDescription()}
+            title={stallTitle}
+            description={stallDescription}
             openGraph={{
                 site_name: import.meta.env.VITE_SITE_NAME,
                 type: "website",
                 url: $page.url.href,
-                title: serverLoadedUser.getShortStallName(),
-                description: serverLoadedUser.getShortStallDescription(),
+                title: stallTitle,
+                description: stallDescription,
                 images: [
                   {
                     url: serverLoadedUser.stall_banner_url ?? serverLoadedUser.profile_image_url ?? "",
-                    alt: serverLoadedUser.getShortStallName(),
+                    alt: stallTitle,
                   }
                 ],
             }}
@@ -70,7 +78,7 @@
                 site: import.meta.env.VITE_TWITTER_USER,
                 handle: import.meta.env.VITE_TWITTER_USER,
                 cardType: "summary_large_image",
-                imageAlt: serverLoadedUser.getShortStallName(),
+                imageAlt: stallTitle,
             }}
     />
 {/if}


### PR DESCRIPTION
New way of getting short titles and descriptions for MetaTags so Twitter is happy. The old system didn't work because the reply was already json, and you cannot call funcions on json...

@ibz the only one that's different is the Stall ones, because I still wanted to provide defaults: when you go to your stall and you didn't edit it before, it'll have no name or description.