### PR TITLE
Lazy loading pictures

### DIFF
--- a/web/frontoffice/package-lock.json
+++ b/web/frontoffice/package-lock.json
@@ -13,6 +13,7 @@
         "bech32": "^2.0.0",
         "buffer": "^6.0.3",
         "light-bolt11-decoder": "^3.0.0",
+        "svelte-lazy-loader": "^1.0.0",
         "svelte-qr": "^1.0.0",
         "uuid": "^9.0.0"
       },
@@ -3893,6 +3894,11 @@
         "svelte": "^3.19.0 || ^4.0.0-next.0"
       }
     },
+    "node_modules/svelte-lazy-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svelte-lazy-loader/-/svelte-lazy-loader-1.0.0.tgz",
+      "integrity": "sha512-AZD6R60vksyojn21FgXLglmBiBB9K5Dkdu0hdGrLbCaRCYT68IsWkZfRUqKhMx1IfzqWcZQ8X9y/f+Ih0oNQkQ=="
+    },
     "node_modules/svelte-markdown": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/svelte-markdown/-/svelte-markdown-0.2.3.tgz",
@@ -6987,6 +6993,11 @@
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.2.tgz",
       "integrity": "sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==",
       "requires": {}
+    },
+    "svelte-lazy-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svelte-lazy-loader/-/svelte-lazy-loader-1.0.0.tgz",
+      "integrity": "sha512-AZD6R60vksyojn21FgXLglmBiBB9K5Dkdu0hdGrLbCaRCYT68IsWkZfRUqKhMx1IfzqWcZQ8X9y/f+Ih0oNQkQ=="
     },
     "svelte-markdown": {
       "version": "0.2.3",

--- a/web/frontoffice/package.json
+++ b/web/frontoffice/package.json
@@ -39,6 +39,7 @@
     "bech32": "^2.0.0",
     "buffer": "^6.0.3",
     "light-bolt11-decoder": "^3.0.0",
+    "svelte-lazy-loader": "^1.0.0",
     "svelte-qr": "^1.0.0",
     "uuid": "^9.0.0"
   }

--- a/web/frontoffice/src/lib/components/stores/ProductCard.svelte
+++ b/web/frontoffice/src/lib/components/stores/ProductCard.svelte
@@ -7,6 +7,7 @@
     import { goto } from "$app/navigation";
     import {EVENT_KIND_AUCTION} from "$lib/services/nostr";
     import AuctionInfo from "$lib/components/stores/AuctionInfo.svelte";
+    import { Image } from 'svelte-lazy-loader';
 
     export let product: string;
     export let onImgError = () => {};
@@ -15,7 +16,14 @@
 </script>
 
 <div class="card w-full md:w-96 bg-base-200 dark:bg-base-300 shadow-xl mx-auto mb-16 md:4">
-    <figure><a href="/product/{product.id}"><img src="{product.images ? product.images[0] : product.image ?? productImageFallback}" on:error={(event) => onImgError(event.srcElement)} /></a></figure>
+    <figure>
+        <a href="/product/{product.id}">
+            <Image
+                    loading="lazy"
+                    placeholder="https://placehold.co/600x400"
+                    src="{product.images ? product.images[0] : product.image ?? productImageFallback}" />
+        </a>
+    </figure>
     <div class="card-body items-center text-center">
         {#if product.event.kind === EVENT_KIND_AUCTION}
             <div class="badge badge-info gap-2">auction</div>

--- a/web/frontoffice/src/lib/components/stores/ProductCardBrowser.svelte
+++ b/web/frontoffice/src/lib/components/stores/ProductCardBrowser.svelte
@@ -130,9 +130,28 @@
                     }
                 } else {
                     // If whiteListedStalls is provided, don't limit the number of loaded products
-                    // If there is no whiteListedStalls, load just maxProductsLoaded products
+                    // If there is no whiteListedStalls, load just maxProductsLoaded products, unless
+                    // maxProductsLoaded is 0 (unlimited)
 
-                    if (whiteListedStalls || (whiteListedStalls === null && productsLoaded < maxProductsLoaded)) {
+                    if (
+                        whiteListedStalls
+                        ||
+                        (
+                            whiteListedStalls === null
+                            &&
+                            (
+                                (
+                                    maxProductsLoaded === 0
+                                )
+                                ||
+                                (
+                                    maxProductsLoaded > 0
+                                    &&
+                                    productsLoaded < maxProductsLoaded
+                                )
+                            )
+                        )
+                    ) {
                         products[productId] = content;
                         productsLoaded++;
                     }

--- a/web/frontoffice/src/lib/components/stores/ProductRow.svelte
+++ b/web/frontoffice/src/lib/components/stores/ProductRow.svelte
@@ -4,6 +4,7 @@
     import {addToCart} from "$lib/shopping";
     import {EVENT_KIND_AUCTION} from "$lib/services/nostr";
     import {goto} from "$app/navigation";
+    import {Image} from "svelte-lazy-loader";
 
     export let product: string;
     export let onImgError = () => {};
@@ -32,7 +33,14 @@
     </td>
     <td>
         <div class="card bg-base-100 shadow-xl w-full lg:w-32">
-            <figure><a href="/product/{product.id}"><img class="rounded-xl" src="{product.images ? product.images[0] : product.image ?? productImageFallback}" on:error={(event) => onImgError(event.srcElement)} /></a></figure>
+            <figure>
+                <a href="/product/{product.id}">
+                    <Image
+                            loading="lazy"
+                            placeholder="https://placehold.co/600x400"
+                            src="{product.images ? product.images[0] : product.image ?? productImageFallback}" />
+                </a>
+            </figure>
         </div>
     </td>
 

--- a/web/frontoffice/src/routes/universe/+page.svelte
+++ b/web/frontoffice/src/routes/universe/+page.svelte
@@ -5,8 +5,10 @@
 <script lang="ts">
     import Titleh1 from "$sharedLib/components/layout/Title-h1.svelte";
     import ProductCardBrowser from "$lib/components/stores/ProductCardBrowser.svelte";
+
+    export let maxProductsLoaded: number = 0;   // Unlimited
 </script>
 
 <Titleh1>Universe</Titleh1>
 
-<ProductCardBrowser />
+<ProductCardBrowser {maxProductsLoaded} />


### PR DESCRIPTION
When going to a page with a lot of products (like Universe, the Homepage or big stalls), slow devices (mobiles?) or devices with slow Internet connections can struggle to even let you scroll the page because they're loading 400 pictures worth 60 MB at the same time. With this change, images are loaded when they're about to enter the viewport, while the user scrolls down, which aleviate a lot the resources of the device and saves data on your data plan if you're on mobile.